### PR TITLE
Add active filter for item endpoint.

### DIFF
--- a/app/control.py
+++ b/app/control.py
@@ -61,7 +61,8 @@ def get_item():
     schema = ItemSchema()
     filter = ItemInterface( 
         category = CategoryInterface(name = request.args.get("category","%") ),  
-        name = request.args.get("name","%")
+        name = request.args.get("name","%"),
+        active = bool(request.args.get("active", "True"))
         )
     filter['Active'] = True
     items : List[ItemInterface] = ItemService.get(filter)

--- a/app/templates/inventory.html
+++ b/app/templates/inventory.html
@@ -76,6 +76,7 @@
             if( name.length > 0 ) {
                 params.append("name", "%" + name + "%")
             }
+            params.append("active", "True");
             var url = "{{url_for('Inventory.get_item')}}?" + params.toString();
             xhtml = new XMLHttpRequest();
             xhtml.onreadystatechange = function() {


### PR DESCRIPTION
This endpoint is what was used for populating the table via AJAX calls but there was not filter, so all items were returned that match name and category.
This applies a filter for only active, although the API will support returning deactivated items.