### PR TITLE
Add unique filter for suggestions

### DIFF
--- a/app/control.py
+++ b/app/control.py
@@ -65,7 +65,7 @@ def get_item():
         active = bool(request.args.get("active", "True"))
         )
     filter['Active'] = True
-    items : List[ItemInterface] = ItemService.get(filter)
+    items : List[ItemInterface] = ItemService.get(filter, request.args.get("unique", False, bool))
 
     return schema.dumps(items, many=True)
 

--- a/app/service.py
+++ b/app/service.py
@@ -1,7 +1,7 @@
 from .interface import CategoryInterface, ItemInterface
 from .model import CCategory, CItem
 from app import db
-from typing import List,Iterator
+from typing import List,Iterator,Dict
 import datetime
 
 
@@ -110,7 +110,7 @@ class ItemService:
         return query.order_by(CItem.added).all()
     
     @staticmethod    
-    def get(filter : ItemInterface = None) -> List[ItemInterface]:
+    def get(filter : ItemInterface = None, unique : bool = False) -> List[ItemInterface]:
         def CItemList2InterfaceList(objs:List[CItem]):
             def CItem2Interface(obj:CItem):
                 return ItemInterface(
@@ -120,7 +120,12 @@ class ItemService:
                     )
             return [CItem2Interface(x) for x in objs]
         
-        return CItemList2InterfaceList( ItemService.get_object(filter) )
+        items = ItemService.get_object(filter)
+        if unique:
+            # remove duplicate name/cateogry items by creating a dictionary key from them
+            dict : Dict[str,CItem] = {f"{x.name}:{x.category.name}" : x for x in items}
+            items = dict.values()
+        return CItemList2InterfaceList( items )
     
     @staticmethod
     def get_name_match(token : str, limit : int = 5, category : CategoryInterface = None ) -> List[str]:

--- a/app/service_test.py
+++ b/app/service_test.py
@@ -60,6 +60,7 @@ class TestCategoryService:
             comparison = CategoryService.get()
             assert len(comparison) == len(categories)
 
+
 @pytest.fixture()
 def categories(db):
     categories = [
@@ -197,3 +198,9 @@ class TestItemService:
         
         assert not test['active']
         assert test['removed'] == datetime.datetime.now().date()
+
+    def test_get_unique_item(self, db, items, categories):
+        """Test that we can filter for unique name/category items"""
+        item = items[5]
+        tests = ItemService.get( ItemInterface(name=item.name, category=CategoryInterface(name=item.category.name)), True)
+        assert len(tests) == 1

--- a/app/templates/inventory.html
+++ b/app/templates/inventory.html
@@ -159,6 +159,7 @@
             }
             if( item.value.length > 0 ) {
                 params.append("name", "%" + item.value + "%");
+                params.append("unique", "True");
                 return "{{url_for('Inventory.get_item')}}?" + params.toString();
             } else {
                 return false;


### PR DESCRIPTION
Fixes the suggestions so that there are not duplicates for the same issue.

This was caused b/c of returning items, which are unique even if the name and category are the same. This will filter items to only have only items with unique name/categories. 

Note that the returned item cannot be relied on.